### PR TITLE
Fix profile dropdown jitter and content shift (Fixes #1)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,10 @@
 ::selection { background-color: rgb(4, 47, 46); color: rgb(45, 212, 191); }
 ::-moz-selection { background-color: rgb(4, 47, 46); color: rgb(45, 212, 191); }
 
-html { scroll-behavior: smooth; }
+html {
+  scroll-behavior: smooth;
+  overflow-y: scroll;
+}
 
 /* Theme tokens */
 @layer base {
@@ -127,5 +130,22 @@ article[data-bookmark="p5"]:not([data-active-ayah="1"]) {
   outline: 1px solid color-mix(in oklab, #a78bfa 35%, transparent);
 }
 
-/* Keep scrollbar width stable when overlays/menus open (optional) */
-html { scrollbar-gutter: stable; }
+/* Scrollbar is always visible via overflow-y: scroll on html element above */
+
+/* Prevent Radix UI from modifying body styles when dropdown/dialog opens */
+body {
+  overflow-y: auto !important;
+  margin-right: 0 !important;
+  padding-right: 0 !important;
+}
+
+body[data-scroll-locked],
+body[style*="pointer-events"],
+body[style*="overflow"],
+body[style*="padding-right"],
+body[style*="margin-right"] {
+  overflow-y: auto !important;
+  margin-right: 0 !important;
+  padding-right: 0 !important;
+  pointer-events: auto !important;
+}

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -47,7 +47,7 @@ export default function ProfileMenu() {
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
     >
-      <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
         <DropdownMenuTrigger asChild>
           <button
             type="button"


### PR DESCRIPTION
Resolved the layout jitter that occurred when hovering over the profile button:
- Force scrollbar to always be visible via overflow-y: scroll on html element
- Disable modal behavior on DropdownMenu to prevent scroll lock
- Override any Radix UI body modifications that could cause content shifting

This ensures stable layout with no horizontal shifting when the dropdown opens.