### PR TITLE
Fix responsive navigation layout and prevent overlap (Fixes #7)

### DIFF
--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -83,12 +83,12 @@ export default function BookmarksPage() {
   }, [rows, filters, sortBy]);
 
   if (loading) {
-    return <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-28">Loading…</div>;
+    return <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">Loading…</div>;
   }
 
   if (!user) {
     return (
-      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-28 space-y-4 text-center">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12 space-y-4 text-center">
         <AppSubnav />
         <h1 className="text-2xl font-bold">Bookmarks</h1>
         <p className="text-muted-foreground">Sign in to view your saved highlights.</p>
@@ -103,7 +103,7 @@ export default function BookmarksPage() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       <AppSubnav />
 
       <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/app/hadith/HadithIndexClient.tsx
+++ b/src/app/hadith/HadithIndexClient.tsx
@@ -22,7 +22,7 @@ export default function HadithIndexClient() {
   }, [q]);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       <div className="text-center">
         <h1 className="text-3xl md:text-4xl font-bold">Hadith</h1>
         <p className="text-muted-foreground mt-1">

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -70,12 +70,12 @@ export default function NotesPage() {
   };
 
   if (loading) {
-    return <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">Loading…</div>;
+    return <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">Loading…</div>;
   }
 
   if (!user) {
     return (
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28 space-y-4 text-center">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12 space-y-4 text-center">
         <AppSubnav />
         <h1 className="text-2xl font-bold">Notes</h1>
         <p className="text-muted-foreground">Sign in to view and manage your reflections.</p>
@@ -90,7 +90,7 @@ export default function NotesPage() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       <AppSubnav />
 
       <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -83,7 +83,7 @@ export default function NotificationsPage() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
         Loading…
       </div>
     );
@@ -91,7 +91,7 @@ export default function NotificationsPage() {
 
   if (!user) {
     return (
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
         <AppSubnav showBack />
         <h1 className="mt-4 text-2xl font-bold">Notifications</h1>
         <p className="text-muted-foreground">Sign in to configure notifications.</p>
@@ -153,7 +153,7 @@ export default function NotificationsPage() {
     });
 
   return (
-    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       <AppSubnav showBack />
 
       <div className="mt-4 flex items-center justify-between">

--- a/src/app/prayer/page.tsx
+++ b/src/app/prayer/page.tsx
@@ -172,7 +172,7 @@ export default function PrayerPage() {
   }, [bearing, deviceHeading]);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       {/* Segmented slider */}
       <div className="mx-auto max-w-md">
         <div className="rounded-full border bg-background/60 backdrop-blur p-1 flex items-center gap-1">

--- a/src/app/quran/[surah]/page.tsx
+++ b/src/app/quran/[surah]/page.tsx
@@ -235,7 +235,7 @@ export default async function SurahPage({
     <>
       <ScrollProgressBar height={2} />
 
-      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-28">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
         {/* HEADER */}
         <SurahTitle id={data.chapter} arabicName={meta.arabicName} englishNick={meta.englishNick} />
 

--- a/src/app/quran/page.tsx
+++ b/src/app/quran/page.tsx
@@ -33,7 +33,7 @@ export default async function QuranIndexPage() {
   const chapters = await getChapters();
 
   return (
-    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       <div className="text-center">
         <h1 className="text-3xl font-bold">Quran</h1>
         <p className="text-muted-foreground mt-1">

--- a/src/app/recent/page.tsx
+++ b/src/app/recent/page.tsx
@@ -47,12 +47,12 @@ export default function RecentReadingsPage() {
   }, [user, loading]);
 
   if (loading) {
-    return <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-28">Loading…</div>;
+    return <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">Loading…</div>;
   }
 
   if (!user) {
     return (
-      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-28 space-y-4 text-center">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12 space-y-4 text-center">
         <AppSubnav />
         <h1 className="text-2xl font-bold">Recent readings</h1>
         <p className="text-muted-foreground">Sign in to continue where you left off.</p>
@@ -116,7 +116,7 @@ export default function RecentReadingsPage() {
   }, [rows, fetching, user]);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       <AppSubnav />
 
       <div className="flex items-center justify-between">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -31,7 +31,7 @@ export default function SearchPage() {
   }, [q]);
 
   return (
-    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-28">
+    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12">
       <h1 className="text-2xl font-bold text-center">Search</h1>
       <div className="mt-6 flex justify-center">
         <Input

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -40,7 +40,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-28 space-y-8">
+    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 pt-32 pb-8 sm:pt-28 sm:pb-12 space-y-8">
       <header>
         <h1 className="text-2xl font-bold">Settings</h1>
         <p className="text-muted-foreground">Theme and reading preferences.</p>

--- a/src/components/AppSubnav.tsx
+++ b/src/components/AppSubnav.tsx
@@ -25,14 +25,14 @@ export default function AppSubnav({
   };
 
   const pillBase =
-    "inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm transition";
+    "inline-flex items-center gap-1.5 sm:gap-2 rounded-full px-2 sm:px-3 py-1.5 text-xs sm:text-sm transition";
   const active = "bg-foreground text-background";
   const idle = "text-foreground/80 hover:bg-foreground/10";
 
   return (
-    <div className="flex items-center justify-between gap-3 mb-5">
-      {/* Left: Back */}
-      <div className="min-w-[80px]">
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-3 mb-5">
+      {/* Left: Back (hidden on mobile, shown on desktop) */}
+      <div className="hidden sm:block sm:min-w-[80px]">
         {showBack && (
           <button
             onClick={goBack}
@@ -44,35 +44,48 @@ export default function AppSubnav({
         )}
       </div>
 
-      {/* Center: Qur’an / Hadith / Prayer pills */}
-      <div className="flex-1 flex items-center justify-center">
-        <div className="inline-flex items-center gap-1 rounded-full border bg-background/60 px-1 py-1 shadow-sm">
+      {/* Center: Qur'an / Hadith / Prayer pills */}
+      <div className="flex-1 flex items-center justify-center w-full sm:w-auto">
+        <div className="inline-flex items-center gap-0.5 sm:gap-1 rounded-full border bg-background/60 px-1 py-1 shadow-sm">
           <Link
             href="/quran"
             className={cn(pillBase, is(/^\/quran(\/|$)/) ? active : idle)}
           >
-            <BookOpen className="h-4 w-4" />
-            Qur’an
+            <BookOpen className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            <span className="hidden xs:inline sm:inline">Qur'an</span>
           </Link>
           <Link
             href="/hadith"
             className={cn(pillBase, is(/^\/hadith(\/|$)/) ? active : idle)}
           >
-            <Library className="h-4 w-4" />
-            Hadith
+            <Library className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            <span className="hidden xs:inline sm:inline">Hadith</span>
           </Link>
           <Link
             href="/prayer"
             className={cn(pillBase, is(/^\/prayer(\/|$)/) ? active : idle)}
           >
-            <Clock className="h-4 w-4" />
-            Prayer
+            <Clock className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            <span className="hidden xs:inline sm:inline">Prayer</span>
           </Link>
         </div>
       </div>
 
-      {/* Right spacer, keeps center truly centered */}
-      <div className="min-w-[80px]" />
+      {/* Mobile: Back button shown below on mobile */}
+      {showBack && (
+        <div className="sm:hidden w-full flex justify-center">
+          <button
+            onClick={goBack}
+            className="inline-flex items-center gap-2 rounded-full border bg-background/60 px-3 py-1.5 text-xs hover:bg-foreground/10"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back
+          </button>
+        </div>
+      )}
+
+      {/* Right spacer, keeps center truly centered on desktop */}
+      <div className="hidden sm:block sm:min-w-[80px]" />
     </div>
   );
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -81,84 +81,158 @@ export function Navigation() {
   return (
     <nav
       className={cn(
-        "fixed w-full top-0 z-50 px-4 py-3 transition-transform duration-200",
+        "fixed w-full top-0 z-50 px-2 sm:px-4 py-2 sm:py-3 transition-transform duration-200",
         hidden ? "-translate-y-full" : "translate-y-0"
       )}
     >
-      <div className="max-w-7xl mx-auto grid grid-cols-3 items-center">
-        {/* brand (left) */}
-        <div className="flex items-center">
-          <Link
-            href={isApp ? "/quran" : "/#home"}
-            className="rounded-full px-3 py-1 font-semibold tracking-tight hover:opacity-90 transition"
-            aria-label="Quran & Sunnah Home"
-          >
-            Quran &amp; Sunnah
-          </Link>
-        </div>
+      <div className="max-w-7xl mx-auto">
+        {/* Mobile: Stack vertically */}
+        <div className="flex flex-col gap-2 md:hidden">
+          {/* Row 1: Brand + Right Controls */}
+          <div className="flex items-center justify-between">
+            <Link
+              href={isApp ? "/quran" : "/#home"}
+              className="rounded-full px-3 py-1 font-semibold tracking-tight hover:opacity-90 transition text-sm"
+              aria-label="Quran & Sunnah Home"
+            >
+              Quran &amp; Sunnah
+            </Link>
+            <div className="flex items-center gap-1">
+              {isLanding ? (
+                <Button asChild size="sm" className="font-normal text-xs h-8">
+                  <Link href="/quran">Open App</Link>
+                </Button>
+              ) : (
+                <>
+                  <Link
+                    href="/search"
+                    className="rounded-full border bg-background/60 backdrop-blur p-2 hover:bg-muted transition"
+                    title="Search"
+                  >
+                    <Search className="h-4 w-4" />
+                  </Link>
 
-        {/* centered island (hidden on utility pages) */}
-        <div className="flex items-center justify-center">
+                  <Link
+                    href="/settings"
+                    className="rounded-full border bg-background/60 backdrop-blur p-2 hover:bg-muted transition"
+                    title="Settings"
+                  >
+                    <Gear className="h-4 w-4" />
+                  </Link>
+
+                  <ProfileMenu iconOnlyBelow="xl" />
+                </>
+              )}
+              <ModeToggle />
+            </div>
+          </div>
+
+          {/* Row 2: Navigation Menu */}
           {!isUtility && (
-            <NavigationMenu>
-              <NavigationMenuList className="whitespace-nowrap bg-gradient-to-r from-foreground/5 via-foreground/10 to-foreground/5 backdrop-blur-md px-5 py-2 rounded-full border border-foreground/10">
-                {links.map(({ href, label, icon: Icon }) => {
-                  const active =
-                    pathname === href ||
-                    pathname.startsWith(href + "/") ||
-                    // allow root match for /quran versus /quran/[surah]
-                    (href !== "/" && pathname.startsWith(href));
-                  return (
-                    <NavigationMenuItem key={href} className="px-2 sm:px-3">
-                      <NavigationMenuLink
-                        href={href}
-                        className={cn(
-                          "flex items-center gap-2 text-sm transition-colors whitespace-nowrap",
-                          active ? "text-foreground" : "text-foreground/80 hover:text-foreground"
-                        )}
-                      >
-                        <Icon className="w-4 h-4" />
-                        <span>{label}</span>
-                      </NavigationMenuLink>
-                    </NavigationMenuItem>
-                  );
-                })}
-              </NavigationMenuList>
-            </NavigationMenu>
+            <div className="flex items-center justify-center">
+              <NavigationMenu>
+                <NavigationMenuList className="whitespace-nowrap bg-gradient-to-r from-foreground/5 via-foreground/10 to-foreground/5 backdrop-blur-md px-3 py-1.5 rounded-full border border-foreground/10">
+                  {links.map(({ href, label, icon: Icon }) => {
+                    const active =
+                      pathname === href ||
+                      pathname.startsWith(href + "/") ||
+                      (href !== "/" && pathname.startsWith(href));
+                    return (
+                      <NavigationMenuItem key={href} className="px-1.5">
+                        <NavigationMenuLink
+                          href={href}
+                          className={cn(
+                            "flex items-center gap-1.5 text-xs transition-colors whitespace-nowrap",
+                            active ? "text-foreground" : "text-foreground/80 hover:text-foreground"
+                          )}
+                        >
+                          <Icon className="w-3.5 h-3.5" />
+                          <span>{label}</span>
+                        </NavigationMenuLink>
+                      </NavigationMenuItem>
+                    );
+                  })}
+                </NavigationMenuList>
+              </NavigationMenu>
+            </div>
           )}
         </div>
 
-        {/* right controls */}
-        <div className="flex items-center justify-end gap-2">
-          {isLanding ? (
-            <Button asChild size="sm" className="font-normal">
-              <Link href="/quran">Open App</Link>
-            </Button>
-          ) : (
-            <>
-              <Link
-                href="/search"
-                className="rounded-full border bg-background/60 backdrop-blur px-3 py-1.5 text-sm hover:bg-muted transition flex items-center gap-2 font-normal"
-                title="Search"
-              >
-                <Search className="h-4 w-4" />
-                <span>Search</span>
-              </Link>
+        {/* Desktop: Flexible grid that prevents overlap */}
+        <div className="hidden md:grid grid-cols-[auto_1fr_auto] items-center gap-4">
+          {/* brand (left) */}
+          <div className="flex items-center shrink-0">
+            <Link
+              href={isApp ? "/quran" : "/#home"}
+              className="rounded-full px-3 py-1 font-semibold tracking-tight hover:opacity-90 transition text-sm xl:text-base whitespace-nowrap"
+              aria-label="Quran & Sunnah Home"
+            >
+              Quran &amp; Sunnah
+            </Link>
+          </div>
 
-              <Link
-                href="/settings"
-                className="rounded-full border bg-background/60 backdrop-blur px-3 py-1.5 text-sm hover:bg-muted transition flex items-center gap-2 font-normal"
-                title="Settings"
-              >
-                <Gear className="h-4 w-4" />
-                <span>Settings</span>
-              </Link>
+          {/* centered island (hidden on utility pages) */}
+          <div className="flex items-center justify-center min-w-0">
+            {!isUtility && (
+              <NavigationMenu>
+                <NavigationMenuList className="whitespace-nowrap bg-gradient-to-r from-foreground/5 via-foreground/10 to-foreground/5 backdrop-blur-md px-3 lg:px-4 xl:px-5 py-2 rounded-full border border-foreground/10">
+                  {links.map(({ href, label, icon: Icon }) => {
+                    const active =
+                      pathname === href ||
+                      pathname.startsWith(href + "/") ||
+                      (href !== "/" && pathname.startsWith(href));
+                    return (
+                      <NavigationMenuItem key={href} className="px-1.5 lg:px-2 xl:px-3">
+                        <NavigationMenuLink
+                          href={href}
+                          className={cn(
+                            "flex items-center gap-1.5 lg:gap-2 text-xs lg:text-sm transition-colors whitespace-nowrap",
+                            active ? "text-foreground" : "text-foreground/80 hover:text-foreground"
+                          )}
+                        >
+                          <Icon className="w-3.5 h-3.5 lg:w-4 lg:h-4" />
+                          <span>{label}</span>
+                        </NavigationMenuLink>
+                      </NavigationMenuItem>
+                    );
+                  })}
+                </NavigationMenuList>
+              </NavigationMenu>
+            )}
+          </div>
 
-              {/* Profile dropdown (auth-gated actions inside) */}
-              <ProfileMenu />
-            </>
-          )}
-          <ModeToggle />
+          {/* right controls */}
+          <div className="flex items-center justify-end gap-1.5 lg:gap-2 shrink-0">
+            {isLanding ? (
+              <Button asChild size="sm" className="font-normal text-xs lg:text-sm">
+                <Link href="/quran">Open App</Link>
+              </Button>
+            ) : (
+              <>
+                <Link
+                  href="/search"
+                  className="rounded-full border bg-background/60 backdrop-blur p-2 xl:px-3 xl:py-1.5 text-sm hover:bg-muted transition flex items-center gap-2 font-normal"
+                  title="Search"
+                >
+                  <Search className="h-4 w-4" />
+                  <span className="hidden xl:inline">Search</span>
+                </Link>
+
+                <Link
+                  href="/settings"
+                  className="rounded-full border bg-background/60 backdrop-blur p-2 xl:px-3 xl:py-1.5 text-sm hover:bg-muted transition flex items-center gap-2 font-normal"
+                  title="Settings"
+                >
+                  <Gear className="h-4 w-4" />
+                  <span className="hidden xl:inline">Settings</span>
+                </Link>
+
+                {/* Profile dropdown (auth-gated actions inside) */}
+                <ProfileMenu iconOnlyBelow="xl" />
+              </>
+            )}
+            <ModeToggle />
+          </div>
         </div>
       </div>
     </nav>

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -21,7 +21,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/components/auth/AuthProvider";
 
-export default function ProfileMenu() {
+export default function ProfileMenu({ iconOnlyBelow }: { iconOnlyBelow?: "sm" | "md" | "lg" | "xl" }) {
   const router = useRouter();
   const { user, loading, logOut } = useAuth();
 
@@ -35,9 +35,16 @@ export default function ProfileMenu() {
     }
   }
 
-  // Same pill look as your Search/Settings links
+  // Determine if we should hide the label based on breakpoint
+  const labelHiddenClass = iconOnlyBelow === "xl" ? "hidden xl:inline" :
+                          iconOnlyBelow === "lg" ? "hidden lg:inline" :
+                          iconOnlyBelow === "md" ? "hidden md:inline" :
+                          iconOnlyBelow === "sm" ? "hidden sm:inline" : "";
+
+  // Icon-only mode uses padding, full mode uses px-3 py-1.5
   const triggerClass = cn(
-    "rounded-full border bg-background/60 backdrop-blur px-3 py-1.5",
+    "rounded-full border bg-background/60 backdrop-blur",
+    iconOnlyBelow ? "p-2 xl:px-3 xl:py-1.5" : "px-3 py-1.5",
     "text-sm hover:bg-muted transition flex items-center gap-2 font-normal"
   );
 
@@ -59,7 +66,7 @@ export default function ProfileMenu() {
             aria-busy={loading || undefined}
           >
             <User className="h-4 w-4" />
-            <span>Profile</span>
+            <span className={labelHiddenClass || undefined}>Profile</span>
           </button>
         </DropdownMenuTrigger>
 


### PR DESCRIPTION
This commit addresses dynamic scaling issues on mobile and desktop:

## Navigation Component Changes:
- Changed desktop layout from rigid grid-cols-3 to flexible grid-cols-[auto_1fr_auto]
- Added responsive breakpoints to prevent navigation menu from overlapping controls
- Implemented icon-only mode for Search, Settings, and Profile on screens below 1280px
- Added proper spacing with gap-4 and shrink-0 to prevent compression
- Scaled down navigation menu items on smaller desktop screens:
  * Font sizes: text-xs lg:text-sm
  * Icons: w-3.5 h-3.5 lg:w-4 lg:h-4
  * Responsive padding at multiple breakpoints

## AppSubnav Component Changes:
- Made pills responsive with smaller text and icons on mobile
- Moved Back button below navigation pills on mobile for better layout
- Text labels hide on very small screens (icon-only pills)
- Reduced gaps and padding on mobile screens

## ProfileMenu Component Changes:
- Added iconOnlyBelow prop to support responsive text hiding
- Switches between p-2 (icon-only) and px-3 py-1.5 (with text) based on breakpoint
- Matches Search and Settings button behavior for consistency

## Page Layout Updates:
- Updated all pages from fixed py-28 to responsive padding
- Mobile: pt-32 pb-8 (8rem top, 2rem bottom)
- Desktop: pt-28 pb-12 (7rem top, 3rem bottom)
- Accounts for mobile navigation stacking vertically and taking more space

Files updated: Navigation.tsx, AppSubnav.tsx, ProfileMenu.tsx, and all page layouts